### PR TITLE
Added example, added better init for egui editor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.4.1"
 edition = "2021"
 
 [features]
-default = ['editor_bevy', 'bevy_reflect', 'inspector-egui']
+default = ['editor_bevy', 'bevy_reflect']
 serialize = ['dep:serde', 'bevy_math/serialize']
 ron = ['serialize', 'dep:ron', 'dep:thiserror']
 bevy_reflect = ['dep:bevy_reflect', 'bevy_math/bevy_reflect', 'bevy_app?/bevy_reflect', 'bevy_ecs?/bevy_reflect']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.4.1"
 edition = "2021"
 
 [features]
-default = ['editor_bevy', 'bevy_reflect']
+default = ['editor_bevy', 'bevy_reflect', 'inspector-egui']
 serialize = ['dep:serde', 'bevy_math/serialize']
 ron = ['serialize', 'dep:ron', 'dep:thiserror']
 bevy_reflect = ['dep:bevy_reflect', 'bevy_math/bevy_reflect', 'bevy_app?/bevy_reflect', 'bevy_ecs?/bevy_reflect']
@@ -60,6 +60,11 @@ required-features = ["editor_egui"]
 name = "egui_only"
 path = "examples/egui_only.rs"
 required-features = ["editor_egui", "ron"]
+
+[[example]]
+name = "inspector_egui"
+path = "examples/inspector_egui.rs"
+required-features = ["inspector-egui"]
 
 # [[bench]]
 # name = "lookup_curve"

--- a/examples/inspector_egui.rs
+++ b/examples/inspector_egui.rs
@@ -1,0 +1,30 @@
+use bevy::prelude::*;
+use bevy_inspector_egui::quick::{AssetInspectorPlugin, ResourceInspectorPlugin};
+
+use bevy_lookup_curve::{LookupCurve, LookupCurvePlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(LookupCurvePlugin)
+        .add_plugins(AssetInspectorPlugin::<LookupCurve>::default())
+        .register_type::<LookupCurveDevState>()
+        .add_plugins(ResourceInspectorPlugin::<LookupCurveDevState>::default())
+        .add_systems(Startup, setup)
+        .run();
+}
+
+#[derive(Resource, Default, Reflect)]
+struct LookupCurveDevState {
+    curve_handle: Handle<LookupCurve>,
+    curve_noasset: LookupCurve,
+}
+
+fn setup(mut commands: Commands, assets: Res<AssetServer>) {
+    let handle = assets.load("example.curve.ron");
+
+    commands.insert_resource(LookupCurveDevState {
+        curve_handle: handle,
+        curve_noasset: LookupCurve::default().with_name("Not asset"),
+    });
+}

--- a/src/editor/editor_egui.rs
+++ b/src/editor/editor_egui.rs
@@ -52,6 +52,35 @@ impl LookupCurveEguiEditor {
         }
     }
 
+    pub fn encompassing_curve(curve: &LookupCurve) -> Self {
+        let mut min_opt: Option<Vec2> = None;
+        let mut max_opt: Option<Vec2> = None;
+        for knot in curve.knots() {
+            if let Some(min) = min_opt {
+                min_opt = Some(min.min(knot.position));
+            } else {
+                min_opt = Some(knot.position);
+            }
+
+            if let Some(max) = max_opt {
+                max_opt = Some(max.max(knot.position));
+            } else {
+                max_opt = Some(knot.position);
+            }
+        }
+
+        let min = min_opt.unwrap_or(Vec2::new(0.0, 0.0));
+        let max = max_opt.unwrap_or(Vec2::new(1.0, 1.0));
+        let diff = max - min;
+
+        // TODO
+        LookupCurveEguiEditor{
+            offset: min - 0.2 * diff,
+            scale: diff * 1.4,
+            ..Default::default()
+        }
+    }
+
     // TODO : Rename these functions and make them clearer
     // Move to a paintcontext? with access to to_screeen / to_canvas
 

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -202,10 +202,9 @@ fn lookup_curve_miniature_with_edit(
     let button_response = lookup_curve_miniature(curve, id, ui);
     if button_response.clicked() {
         ui.memory_mut(|mem| {
-            let editor = LookupCurveEguiEditor::encompassing_curve(curve);
             mem.data.insert_temp(
                 editor_id,
-                Arc::new(Mutex::new(editor)),
+                Arc::new(Mutex::new(LookupCurveEguiEditor::encompassing_curve(curve))),
             )
         });
     }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -8,6 +8,7 @@ use bevy_app::{App, Plugin};
 use bevy_asset::{Assets, Handle};
 use bevy_inspector_egui::inspector_egui_impls::InspectorEguiImpl;
 use bevy_inspector_egui::reflect_inspector::InspectorUi;
+use bevy_math::Vec2;
 use bevy_reflect::{Reflect, TypeRegistry};
 
 pub(crate) struct InspectorPlugin;
@@ -201,9 +202,10 @@ fn lookup_curve_miniature_with_edit(
     let button_response = lookup_curve_miniature(curve, id, ui);
     if button_response.clicked() {
         ui.memory_mut(|mem| {
+            let editor = LookupCurveEguiEditor::encompassing_curve(curve);
             mem.data.insert_temp(
                 editor_id,
-                Arc::new(Mutex::new(LookupCurveEguiEditor::default())),
+                Arc::new(Mutex::new(editor)),
             )
         });
     }


### PR DESCRIPTION
This PR adds two things:
- A new example showing the usage of the `inspector-egui`
- added `encompassing_curve` which initialized the viewport of a `LookupCurveEguiEditor` to encompass the curve