### PR TITLE
Use the most recent PRs on the bevy_egui and bevy-inspector-egui crates for Bevy 0.15.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,16 @@ version = "0.5.1"
 edition = "2021"
 
 [features]
-#default = ['editor_bevy', 'bevy_reflect']
-default = ['bevy_asset']
+default = ['editor_bevy', 'bevy_reflect']
 serialize = ['dep:serde', 'bevy_math/serialize']
 ron = ['serialize', 'dep:ron', 'dep:thiserror']
 bevy_reflect = ['dep:bevy_reflect', 'bevy_math/bevy_reflect', 'bevy_app?/bevy_reflect', 'bevy_ecs?/bevy_reflect']
 bevy_app = ['dep:bevy_app', 'dep:bevy_log']
 bevy_asset = ['ron', 'bevy_app', 'bevy_reflect', 'dep:bevy_asset']
-# bevy_egui = ['dep:bevy_egui', 'dep:bevy_winit', 'bevy_winit/x11']
-# editor_egui = ['dep:egui']
-# editor_bevy = ['bevy_app', 'bevy_ecs', 'bevy_asset', 'bevy_egui', 'editor_egui']
-# inspector-egui = ['bevy_reflect', 'bevy_app', 'bevy_ecs', 'bevy_asset', 'bevy_egui', 'editor_egui', 'dep:bevy-inspector-egui', 'dep:egui_plot']
+bevy_egui = ['dep:bevy_egui', 'dep:bevy_winit', 'bevy_winit/x11']
+editor_egui = ['dep:egui']
+editor_bevy = ['bevy_app', 'bevy_ecs', 'bevy_asset', 'bevy_egui', 'editor_egui']
+inspector-egui = ['bevy_reflect', 'bevy_app', 'bevy_ecs', 'bevy_asset', 'bevy_egui', 'editor_egui', 'dep:bevy-inspector-egui', 'dep:egui_plot']
 
 [dependencies]
 bevy_math = { version = "0.15.0-rc.2", default-features = false }
@@ -36,38 +35,38 @@ thiserror = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
 ron = { version = "0.8", optional = true }
 
-# egui = { version = "0.28", optional = true }
-# bevy_egui = { version = "0.29", default-features = false, features = ["render"], optional = true }
+egui = { version = "0.29", optional = true }
+bevy_egui = { git = "https://github.com/Vrixyz/bevy_egui.git", branch = "bevy_main", default-features = false, features = ["render"], optional = true }
 
-# bevy-inspector-egui = { version = "0.26.0", default-features = false, features = ["bevy_render"], optional = true }
-# egui_plot = { version = "0.28", optional = true }
+bevy-inspector-egui = { git = "https://github.com/Vrixyz/bevy-inspector-egui.git", branch = "bevy_0.15", default-features = false, features = ["bevy_render"], optional = true }
+egui_plot = { version = "0.29", optional = true }
 
 [dev-dependencies]
 bevy = "0.15.0-rc.2"
-# bevy-inspector-egui = "0.26.0"
+bevy-inspector-egui = { git = "https://github.com/Vrixyz/bevy-inspector-egui.git", branch = "bevy_0.15" }
 criterion = "0.5.1"
 rand = "0.8.5"
-# eframe = "0.28"
+eframe = "0.29"
 
-# [[example]]
-# name = "dev"
-# path = "examples/dev.rs"
-# required-features = ["editor_bevy", "bevy_reflect"]
+[[example]]
+name = "dev"
+path = "examples/dev.rs"
+required-features = ["editor_bevy", "bevy_reflect"]
 
-# [[example]]
-# name = "animation"
-# path = "examples/animation.rs"
-# required-features = ["editor_egui"]
+[[example]]
+name = "animation"
+path = "examples/animation.rs"
+required-features = ["editor_egui"]
 
-# [[example]]
-# name = "egui_only"
-# path = "examples/egui_only.rs"
-# required-features = ["editor_egui", "ron"]
+[[example]]
+name = "egui_only"
+path = "examples/egui_only.rs"
+required-features = ["editor_egui", "ron"]
 
-# [[example]]
-# name = "inspector_egui"
-# path = "examples/inspector_egui.rs"
-# required-features = ["inspector-egui"]
+[[example]]
+name = "inspector_egui"
+path = "examples/inspector_egui.rs"
+required-features = ["inspector-egui"]
 
 # [[bench]]
 # name = "lookup_curve"
@@ -78,3 +77,6 @@ rand = "0.8.5"
 name = "knot_search"
 path = "benches/knot_search.rs"
 harness = false
+
+[patch.crates-io]
+bevy_egui = { git = "https://github.com/Vrixyz/bevy_egui.git", branch = "bevy_main" }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -6,9 +6,11 @@ use std::{
 use crate::{editor::LookupCurveEguiEditor, LookupCache, LookupCurve};
 use bevy_app::{App, Plugin};
 use bevy_asset::{Assets, Handle};
-use bevy_inspector_egui::inspector_egui_impls::InspectorEguiImpl;
 use bevy_inspector_egui::reflect_inspector::InspectorUi;
-use bevy_reflect::{Reflect, TypeRegistry};
+use bevy_inspector_egui::{
+    inspector_egui_impls::InspectorEguiImpl, reflect_inspector::ProjectorReflect,
+};
+use bevy_reflect::{PartialReflect, TypeRegistry};
 
 pub(crate) struct InspectorPlugin;
 
@@ -44,8 +46,8 @@ type InspectorEguiImplFnMany = for<'a> fn(
     &dyn Any,
     egui::Id,
     InspectorUi<'_, '_>,
-    &mut [&mut dyn Reflect],
-    &dyn Fn(&mut dyn Reflect) -> &mut dyn Reflect,
+    &mut [&mut dyn PartialReflect],
+    &dyn ProjectorReflect,
 ) -> bool;
 
 fn add_raw<T: 'static>(
@@ -65,8 +67,8 @@ fn many_unimplemented(
     _options: &dyn Any,
     _id: egui::Id,
     _env: InspectorUi<'_, '_>,
-    _values: &mut [&mut dyn Reflect],
-    _projector: &dyn Fn(&mut dyn Reflect) -> &mut dyn Reflect,
+    _values: &mut [&mut dyn PartialReflect],
+    _projector: &dyn ProjectorReflect,
 ) -> bool {
     ui.label("LookupCurve does not support multi-editing.");
     false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,35 +7,33 @@ use knot_search::KnotSearch;
 #[cfg(feature = "bevy_asset")]
 pub mod asset;
 
-//#[cfg(feature = "editor_egui")]
-//pub mod editor;
+#[cfg(feature = "editor_egui")]
+pub mod editor;
 
-// #[cfg(feature = "inspector-egui")]
-// mod inspector;
+#[cfg(feature = "inspector-egui")]
+mod inspector;
 
 /// Registers the asset loader and editor components
-// #[cfg(any(
-//     feature = "bevy_asset",
-//     feature = "editor_bevy",
-//     feature = "inspector-egui"
-// ))]
-#[cfg(feature = "bevy_asset")]
+#[cfg(any(
+    feature = "bevy_asset",
+    feature = "editor_bevy",
+    feature = "inspector-egui"
+))]
 pub struct LookupCurvePlugin;
 
-// #[cfg(any(
-//     feature = "bevy_asset",
-//     feature = "editor_bevy",
-//     feature = "inspector-egui"
-// ))]
-#[cfg(feature = "bevy_asset")]
+#[cfg(any(
+    feature = "bevy_asset",
+    feature = "editor_bevy",
+    feature = "inspector-egui"
+))]
 impl bevy_app::Plugin for LookupCurvePlugin {
     fn build(&self, app: &mut bevy_app::App) {
         #[cfg(feature = "bevy_asset")]
         app.add_plugins(asset::AssetPlugin);
-        // #[cfg(feature = "editor_bevy")]
-        // app.add_plugins(editor::EditorPlugin);
-        // #[cfg(feature = "inspector-egui")]
-        // app.add_plugins(inspector::InspectorPlugin);
+        #[cfg(feature = "editor_bevy")]
+        app.add_plugins(editor::EditorPlugin);
+        #[cfg(feature = "inspector-egui")]
+        app.add_plugins(inspector::InspectorPlugin);
     }
 }
 


### PR DESCRIPTION
This is using https://github.com/mvlabat/bevy_egui/pull/309 and https://github.com/jakobhellermann/bevy-inspector-egui/pull/221. Please note this is a PR to the existing Bevy 0.15 PR.

Obviously this is temporary, but it gets this compiling for users (like me) who want to migrate to Bevy 0.15 already.