### PR TITLE
Update to egui 0.30, bevy_egui 0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [UNRELEASED] - TBD
+
+### Updated
+- egui to `0.30`
+- bevy_inspector_egui to `?`
+
 ## [0.6.0] - 03-Dec-2024
 Update to Bevy 0.15 🥳
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,22 +49,22 @@ thiserror = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
 ron = { version = "0.8", optional = true }
 
-egui = { version = "0.29", optional = true }
-bevy_egui = { version = "0.31", default-features = false, features = [
+egui = { version = "0.30", optional = true }
+bevy_egui = { version = "0.32", default-features = false, features = [
     "render",
 ], optional = true }
 
-bevy-inspector-egui = { version = "0.28.0", default-features = false, features = [
+bevy-inspector-egui = { git = "https://github.com/blip-radar/bevy-inspector-egui.git", branch = "egui-0.30", default-features = false, features = [
     "bevy_render",
 ], optional = true }
-egui_plot = { version = "0.29", optional = true }
+egui_plot = { version = "0.30", optional = true }
 
 [dev-dependencies]
 bevy = "0.15"
-bevy-inspector-egui = { version = "0.28.0" }
+bevy-inspector-egui = { git = "https://github.com/blip-radar/bevy-inspector-egui.git", branch = "egui-0.30" }
 criterion = "0.5.1"
 rand = "0.8.5"
-eframe = "0.29"
+eframe = "0.30"
 
 [[example]]
 name = "dev"


### PR DESCRIPTION
Bumped:
- egui to 0.30
- egui_plot to 0.30
- bevy_egui to 0.32
- eframe to 0.30

TODO:
-  [ ] Wait for https://github.com/jakobhellermann/bevy-inspector-egui/pull/233 to get merged and published. Then replace temporary git dep.